### PR TITLE
don't specify host in route yaml

### DIFF
--- a/monitoring/route-prometheus.yaml
+++ b/monitoring/route-prometheus.yaml
@@ -4,7 +4,6 @@ metadata:
   name: prometheus
   namespace: myproject
 spec:
-  host: prometheus-myproject.127.0.0.1.nip.io
   port:
     targetPort: prometheus
   to:


### PR DESCRIPTION
removed this line, and k8s did the right thing