### PR TITLE
Updates to get it working on recent versions of Kubernetes and OpenShift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .history
-
+/**/*.updated

--- a/deploy-monitoring.sh
+++ b/deploy-monitoring.sh
@@ -1,14 +1,19 @@
 #!/bin/bash
 
 # Change the namespace to that of your project
-NAMESPACE=myproject
+NAMESPACE=${1:-myproject}
+ISOCP=false
 
 # Get the current directory
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
+# Test if running against an OpenShift cluster
+kubectl get route > /dev/null 2>&1
+[[ $? -eq 0 ]] && ISOCP=true
+
 # Prometheus / Alertmanager
 kubectl apply -f $DIR/monitoring/alerting-interconnect.yaml -n $NAMESPACE
-kubectl apply -f $DIR/monitoring/prometheus.yaml -n $NAMESPACE
+cat $DIR/monitoring/prometheus.yaml | sed "s/myproject/${NAMESPACE}/g" | kubectl apply -n $NAMESPACE -f -
 kubectl apply -f $DIR/monitoring/alertmanager.yaml -n $NAMESPACE
 kubectl expose service/prometheus -n $NAMESPACE
 
@@ -16,13 +21,16 @@ echo "Waiting for Prometheus server to be ready..."
 kubectl rollout status deployment/prometheus -w -n $NAMESPACE
 kubectl rollout status deployment/alertmanager -w -n $NAMESPACE
 echo "...Prometheus server ready"
-kubectl create -f $DIR/monitoring/route-alertmanager.yaml -n $NAMESPACE
-kubectl create -f $DIR/monitoring/route-prometheus.yaml -n $NAMESPACE
+if $ISOCP; then
+    kubectl create -f $DIR/monitoring/route-alertmanager.yaml -n $NAMESPACE
+    kubectl create -f $DIR/monitoring/route-prometheus.yaml -n $NAMESPACE
+fi
 
 # Preparing Grafana datasource and dashboards
+sed -e "s/myproject/${NAMESPACE}/g" $DIR/monitoring/grafana-dashboard-provider.yaml > $DIR/monitoring/grafana-dashboard-provider.yaml.updated
 kubectl create configmap grafana-config \
     --from-file=datasource.yaml=$DIR/monitoring/dashboards/datasource.yaml \
-    --from-file=grafana-dashboard-provider.yaml=$DIR/monitoring/grafana-dashboard-provider.yaml \
+    --from-file=grafana-dashboard-provider.yaml=$DIR/monitoring/grafana-dashboard-provider.yaml.updated \
     --from-file=interconnect-dashboard.json=$DIR/monitoring/dashboards/interconnect-raw.json \
     --from-file=interconnect-dashboard-delayed.json=$DIR/monitoring/dashboards/interconnect-delayed.json \
     -n $NAMESPACE
@@ -33,6 +41,8 @@ kubectl expose service/grafana -n $NAMESPACE
 
 echo "Waiting for Grafana server to be ready..."
 kubectl rollout status deployment/grafana -w -n $NAMESPACE
-kubectl create -f $DIR/monitoring/route-grafana.yaml -n $NAMESPACE
+if $ISOCP; then
+    kubectl create -f $DIR/monitoring/route-grafana.yaml -n $NAMESPACE
+fi
 
 echo "...Grafana server ready"

--- a/monitoring/alertmanager.yaml
+++ b/monitoring/alertmanager.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: alertmanager
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: alertmanager
   template:
     metadata:
       labels:

--- a/monitoring/grafana.yaml
+++ b/monitoring/grafana.yaml
@@ -1,12 +1,15 @@
 # This is not a recommended configuration, and further support should be available
 # from the Prometheus and Grafana communities.
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: grafana
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: grafana
   template:
     metadata:
       labels:

--- a/monitoring/route-alertmanager.yaml
+++ b/monitoring/route-alertmanager.yaml
@@ -2,9 +2,7 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: alertmanager
-  namespace: myproject
 spec:
-  host: alertmanager-myproject.127.0.0.1.nip.io
   port:
     targetPort: alertmanager
   to:

--- a/monitoring/route-grafana.yaml
+++ b/monitoring/route-grafana.yaml
@@ -2,9 +2,7 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: grafana
-  namespace: myproject
 spec:
-  host: grafana-myproject.127.0.0.1.nip.io
   port:
     targetPort: grafana
   to:

--- a/monitoring/route-prometheus.yaml
+++ b/monitoring/route-prometheus.yaml
@@ -2,7 +2,6 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: prometheus
-  namespace: myproject
 spec:
   port:
     targetPort: prometheus


### PR DESCRIPTION
@ErnieAllen and @pwright please review the changes here.
I tested it locally against a minikube cluster and also against an OCP 4.6 cluster.

Script was failing here and so the changes in this PR will fix the issues I found and
I am also allowing the `NAMESPACE` to be specified as the 1st argument to the
`deploy-monitoring.sh` script (if not informed, then it uses the original `myproject`).